### PR TITLE
Fix build due to missing pip pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apk -U upgrade && \
         python3-dev \
         && \
     pip3 --no-cache-dir install setuptools && \
-    pip3 --no-cache-dir install requirements && \
     git clone --depth 1 https://github.com/pymedusa/Medusa.git /medusa && \
     apk del make gcc g++ python-dev && \
     rm -rf /tmp && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# docker sickrage
+# docker medusa
 
-This is a Dockerfile to set up "SickRage" - (https://sickrage.github.io/)
+This is a Dockerfile to set up "pyMedusa" - (https://pymedusa.com/)
 
 Build from docker file
 


### PR DESCRIPTION
It appears as if something went missing from pip and is now causing the
build to fail. Let's see if we even needed that.